### PR TITLE
Changes to the default my.cnf so it works with multi-master

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -73,6 +73,11 @@ class tungsten (
     skipHostConfig                  => $skipHostConfig
 	}
 	
+	# The tungsten::mysql module must be define before tungsten::tungsten
+	if $installMysql == true {
+		include mysql
+	}
+	
 	Class["tungsten::prereq"] ->
 	class { "tungsten::tungsten":
 		installReplicatorSoftware 			=> $installReplicatorSoftware,
@@ -85,11 +90,5 @@ class tungsten (
 			applicationPort 							=> $applicationPort,
 		provision 											=> $provisionNode,
 			provisionDonor 								=> $provisionDonor,
-	}
-
-  # Include the tungsten::mysql module after everything else so it can use
-  # settings invoked in other tungsten submodules
-	if $installMysql == true {
-		include mysql
 	}
 }

--- a/templates/my.erb
+++ b/templates/my.erb
@@ -18,25 +18,31 @@
 #
 [mysqld]
 datadir=<%= scope.lookupvar('::tungsten::mysql::server::datadir') %>
+pid-file=<%= scope.lookupvar('::tungsten::mysql::server::pidfile') %>
 socket=<%= scope.lookupvar('::tungsten::mysql::server::socket') %>
+port=<%= scope.lookupvar('::tungsten::mysql::server::port') %>
+
 user=mysql
 symbolic-links=0
 default-storage-engine=innodb
-pid-file=<%= scope.lookupvar('::tungsten::mysql::server::pidfile') %>
-
 log-bin=mysql-bin
-binlog_format=ROW
+server-id=<%= scope.lookupvar('::tungsten::mysql::server::serverId') %>
+
+# Preferred Tungsten settings
 sync_binlog=2
 max_allowed_packet=52m
 open_files_limit=65535
 max_connections=151
 
-<% clusterHash = scope.lookupvar('::tungsten::tungsten::clusterData') -%>
-<% fqdn = scope.lookupvar('::tungsten::prereq::nodeHostName') -%>
+<% 
+# Use the variables from the ::tungsten:: scope because it must be
+# defined before the tungsten::mysql module is parsed
+clusterHash = scope.lookupvar('::tungsten::clusterData')
+fqdn = scope.lookupvar('::tungsten::nodeHostName')
+-%>
+# Settings to properly support multi-master topologies
+binlog_format=ROW
 auto_increment_increment=<%= scope.function_getMySQLAutoIncrementIncrement([clusterHash]) %>
 auto_increment_offset=<%= scope.function_getMySQLAutoIncrementOffset([clusterHash, fqdn]) %>
-
-server-id=<%= scope.lookupvar('::tungsten::mysql::server::serverId') %>
-port=<%= scope.lookupvar('::tungsten::mysql::server::port') %>
 
 !includedir /etc/mysql/conf.d/

--- a/templates/tungsten.erb
+++ b/templates/tungsten.erb
@@ -11,33 +11,43 @@ application-user=<%= scope.lookupvar('::tungsten::tungsten::appUser') %>
 application-password=<%= scope.lookupvar('::tungsten::tungsten::appPassword') %>
 skip-validation-check=MySQLPermissionsCheck
 start-and-report=true
-<% if scope.lookupvar('::tungsten::tungsten::installReplicatorSoftware') != false -%>
-<% if scope.lookupvar('::tungsten::tungsten::installClusterSoftware') != false -%>
 
+<% if scope.lookupvar('::tungsten::tungsten::installReplicatorSoftware') != false -%>
+  <%- if scope.lookupvar('::tungsten::tungsten::installClusterSoftware') != false -%>
 [defaults.replicator]
 home-directory=/opt/replicator
 rmi-port=10002
+
+  <%- end -%>
 <% end -%>
-<% end -%>
-<% clusterHash = scope.lookupvar('::tungsten::tungsten::clusterData') -%>
-<% scope.function_getTungstenINIDefaultsSections([clusterHash]).each do |key| -%>
-<% cluster = clusterHash[key] -%>
+<%
+clusterHash = scope.lookupvar('::tungsten::tungsten::clusterData')
+
+# All sections that start with "defaults"
+scope.function_getTungstenINIDefaultsSections([clusterHash]).each do |key| -%>
+  <%- cluster = clusterHash[key] -%>
 [<%= key -%>]
-<% cluster.keys.sort.each do |c_key| -%>
+  <%- cluster.keys.sort.each do |c_key| -%>
 <%= c_key -%>=<%= cluster[c_key] %>
+  <%- end -%>
+
 <% end -%>
-<% end -%>
-<% scope.function_getTungstenINIClusteredSections([clusterHash]).each do |key| -%>
-<% cluster = clusterHash[key] -%>
+<%
+# All sections that do not have a topology, or have topology = "clustered"
+scope.function_getTungstenINIClusteredSections([clusterHash]).each do |key| -%>
+  <%- cluster = clusterHash[key] -%>
 [<%= key -%>]
-<% cluster.keys.sort.each do |c_key| -%>
+  <%- cluster.keys.sort.each do |c_key| -%>
 <%= c_key -%>=<%= cluster[c_key] %>
+  <%- end -%>
+
 <% end -%>
-<% end -%>
-<% scope.function_getTungstenININonClusteredSections([clusterHash]).each do |key| -%>
-<% cluster = clusterHash[key] -%>
+<%
+# All remaining sections
+scope.function_getTungstenININonClusteredSections([clusterHash]).each do |key| -%>
+  <%- cluster = clusterHash[key] -%>
 [<%= key -%>]
-<% cluster.keys.sort.each do |c_key| -%>
+  <%- cluster.keys.sort.each do |c_key| -%>
 <%= c_key -%>=<%= cluster[c_key] %>
-<% end -%>
+  <%- end -%>
 <% end -%>


### PR DESCRIPTION
Update the my.cnf so it has a default configuration that is more compatible with all replication topologies.
- Enable row-based binary logs
- Include auto_increment_increment and auto_increment_offset values
