### PR TITLE
Make sure that `tpm update` is run after changing the INI contents.

### DIFF
--- a/manifests/prereq/unix_user.pp
+++ b/manifests/prereq/unix_user.pp
@@ -136,6 +136,14 @@ class tungsten::prereq::unix_user(
 		mode	 => 700,
 		require => User["tungsten::systemUser"],
 	}
+	
+	file { "/opt/replicator/service_logs":
+		ensure => "directory",
+		owner	=> $systemUserName,
+		group	=> $systemUserName,
+		mode	 => 700,
+		require => User["tungsten::systemUser"]
+	}
 
 	file { "/etc/tungsten":
 		ensure => "directory",

--- a/manifests/tungsten.pp
+++ b/manifests/tungsten.pp
@@ -47,8 +47,12 @@ class tungsten::tungsten (
 		class{ "tungsten::tungsten::ini": }->
 		anchor{ "tungsten::tungsten::ini": }
 
-		Anchor["tungsten::tungsten::replicator"] ->
-		class{ "tungsten::tungsten::update": }
+    # Scheduling updates to existing installations must be done 
+    # before the clustering or replication software is installed.
+    # If not, `tpm update` will be run twice during the initial
+    # installation process.
+    class{ "tungsten::tungsten::update": } ->
+		Anchor["tungsten::tungsten::cluster"]
 	} elsif $writeTungstenDefaults == true {
 		class{ "tungsten::tungsten::defaultsini": }->
 		anchor{ "tungsten::tungsten::ini": }

--- a/manifests/tungsten/replicator.pp
+++ b/manifests/tungsten/replicator.pp
@@ -57,7 +57,7 @@ class tungsten::tungsten::replicator (
     		} ~>
     		exec { "install-tungsten-replicator":
     		  path => ["/bin", "/usr/bin"],
-    		  command => "sudo -i -u $tungsten::prereq::systemUserName /opt/continuent/software/$basename/tools/tpm update --tty --log=/opt/continuent/service_logs/tungsten-configure.log > /opt/continuent/service_logs/rpm.output 2>&1",
+    		  command => "sudo -i -u $tungsten::prereq::systemUserName /opt/continuent/software/$basename/tools/tpm update --tty --log=/opt/replicator/service_logs/tungsten-configure.log > /opt/replicator/service_logs/rpm.output 2>&1",
     		  onlyif => "test -f /etc/tungsten/tungsten.ini",
       		refreshonly => true,
       		returns => [0, 1],

--- a/manifests/tungsten/update.pp
+++ b/manifests/tungsten/update.pp
@@ -18,19 +18,19 @@ class tungsten::tungsten::update (
 ) inherits tungsten::params {
   # Run /opt/continuent/tungsten/tools/tpm update if there is a change to tungsten.ini
 	exec { "tungsten::tungsten::update::opt_continuent":
-		path => ["/usr/bin"],
-		command => "sudo -i -u tungsten /opt/continuent/tungsten/tools/tpm update --log=/opt/continuent/service_logs/tungsten-configure.log",
+		path => ["/bin", "/usr/bin"],
+		command => "sudo -i -u $tungsten::prereq::systemUserName /opt/continuent/tungsten/tools/tpm update --tty > /opt/continuent/service_logs/puppet-update.output 2>&1",
 		subscribe => File["/etc/tungsten/tungsten.ini"],
-		onlyif => "test -f /opt/continuent/tungsten",
+		onlyif => "test -e /opt/continuent/tungsten",
 		refreshonly => true
 	}
 	
 	# Run /opt/replicator/tungsten/tools/tpm update if there is a change to tungsten.ini
 	exec { "tungsten::tungsten::update::opt_replicator":
-		path => ["/usr/bin"],
-		command => "sudo -i -u tungsten /opt/replicator/tungsten/tools/tpm update --log=/opt/continuent/service_logs/tungsten-configure.log",
+		path => ["/bin", "/usr/bin"],
+		command => "sudo -i -u $tungsten::prereq::systemUserName /opt/replicator/tungsten/tools/tpm update --tty > /opt/replicator/service_logs/puppet-update.output 2>&1",
 		subscribe => File["/etc/tungsten/tungsten.ini"],
-		onlyif => "test -f /opt/replicator/tungsten",
+		onlyif => "test -e /opt/replicator/tungsten",
 		refreshonly => true
 	}
 }


### PR DESCRIPTION
Fix an issue where `tpm update` then ran twice during the initial install.
Store `tpm update` output in /opt/continuent/service_logs and /opt/replicator/service_logs for their respective installs.